### PR TITLE
test: response-cache different schema

### DIFF
--- a/packages/plugins/response-cache/__tests__/response-cache.spec.ts
+++ b/packages/plugins/response-cache/__tests__/response-cache.spec.ts
@@ -1,132 +1,205 @@
 import { createYoga, createSchema } from 'graphql-yoga'
 import { useResponseCache } from '@graphql-yoga/plugin-response-cache'
 
-const schema = createSchema({
-  typeDefs: /* GraphQL */ `
-    type Query {
-      _: String
+describe('response cache', () => {
+  it('cache a query operation', async () => {
+    const schema = createSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          _: String
+        }
+      `,
+    })
+
+    const yoga = createYoga({
+      plugins: [
+        useResponseCache({
+          session: () => null,
+          includeExtensionMetadata: true,
+        }),
+      ],
+      schema,
+    })
+    function fetch() {
+      return yoga.fetch('http://localhost:3000/graphql', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ query: '{__typename}' }),
+      })
     }
-  `,
-})
 
-it('cache a query operation', async () => {
-  const yoga = createYoga({
-    plugins: [
-      useResponseCache({
-        session: () => null,
-        includeExtensionMetadata: true,
-      }),
-    ],
-    schema,
+    let response = await fetch()
+
+    expect(response.status).toEqual(200)
+    let body = await response.json()
+    expect(body).toEqual({
+      data: {
+        __typename: 'Query',
+      },
+      extensions: {
+        responseCache: {
+          didCache: true,
+          hit: false,
+          ttl: null,
+        },
+      },
+    })
+
+    response = await fetch()
+    expect(response.status).toEqual(200)
+    body = await response.json()
+    expect(body).toEqual({
+      data: {
+        __typename: 'Query',
+      },
+      extensions: {
+        responseCache: {
+          hit: true,
+        },
+      },
+    })
   })
-  function fetch() {
-    return yoga.fetch('http://localhost:3000/graphql', {
+
+  it('cache a query operation per session', async () => {
+    const schema = createSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          _: String
+        }
+      `,
+    })
+
+    const yoga = createYoga({
+      plugins: [
+        useResponseCache({
+          session: (request) => request.headers.get('x-session-id') ?? null,
+          includeExtensionMetadata: true,
+        }),
+      ],
+      schema,
+    })
+    function fetch(sessionId: string) {
+      return yoga.fetch('http://localhost:3000/graphql', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-session-id': sessionId,
+        },
+        body: JSON.stringify({ query: '{__typename}' }),
+      })
+    }
+
+    let response = await fetch('1')
+
+    expect(response.status).toEqual(200)
+    let body = await response.json()
+    expect(body).toEqual({
+      data: {
+        __typename: 'Query',
+      },
+      extensions: {
+        responseCache: {
+          didCache: true,
+          hit: false,
+          ttl: null,
+        },
+      },
+    })
+
+    response = await fetch('1')
+    expect(response.status).toEqual(200)
+    body = await response.json()
+    expect(body).toEqual({
+      data: {
+        __typename: 'Query',
+      },
+      extensions: {
+        responseCache: {
+          hit: true,
+        },
+      },
+    })
+
+    response = await fetch('2')
+
+    expect(response.status).toEqual(200)
+    body = await response.json()
+    expect(body).toEqual({
+      data: {
+        __typename: 'Query',
+      },
+      extensions: {
+        responseCache: {
+          didCache: true,
+          hit: false,
+          ttl: null,
+        },
+      },
+    })
+  })
+
+  it('does not mix the cache of different schemas', async () => {
+    const firstSchema = createSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          hi: String!
+        }
+      `,
+      resolvers: {
+        Query: {
+          hi: () => 'Hello',
+        },
+      },
+    })
+
+    const secondSchema = createSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          hi: String!
+        }
+      `,
+      resolvers: {
+        Query: {
+          hi: () => 'Ola',
+        },
+      },
+    })
+
+    let currentSchema = firstSchema
+
+    const yoga = createYoga({
+      schema: () => currentSchema,
+      plugins: [
+        useResponseCache({
+          session: () => null,
+        }),
+      ],
+    })
+
+    let response = await yoga.fetch('http://yoga/graphql', {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
       },
-      body: JSON.stringify({ query: '{__typename}' }),
+      body: JSON.stringify({ query: '{ hi }' }),
     })
-  }
 
-  let response = await fetch()
+    expect(response.status).toEqual(200)
+    expect(await response.json()).toEqual({ data: { hi: 'Hello' } })
 
-  expect(response.status).toEqual(200)
-  let body = await response.json()
-  expect(body).toEqual({
-    data: {
-      __typename: 'Query',
-    },
-    extensions: {
-      responseCache: {
-        didCache: true,
-        hit: false,
-        ttl: null,
-      },
-    },
-  })
+    currentSchema = secondSchema
 
-  response = await fetch()
-  expect(response.status).toEqual(200)
-  body = await response.json()
-  expect(body).toEqual({
-    data: {
-      __typename: 'Query',
-    },
-    extensions: {
-      responseCache: {
-        hit: true,
-      },
-    },
-  })
-})
-
-it('cache a query operation per session', async () => {
-  const yoga = createYoga({
-    plugins: [
-      useResponseCache({
-        session: (request) => request.headers.get('x-session-id') ?? null,
-        includeExtensionMetadata: true,
-      }),
-    ],
-    schema,
-  })
-  function fetch(sessionId: string) {
-    return yoga.fetch('http://localhost:3000/graphql', {
+    response = await yoga.fetch('http://yoga/graphql', {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
-        'x-session-id': sessionId,
       },
-      body: JSON.stringify({ query: '{__typename}' }),
+      body: JSON.stringify({ query: '{ hi }' }),
     })
-  }
 
-  let response = await fetch('1')
-
-  expect(response.status).toEqual(200)
-  let body = await response.json()
-  expect(body).toEqual({
-    data: {
-      __typename: 'Query',
-    },
-    extensions: {
-      responseCache: {
-        didCache: true,
-        hit: false,
-        ttl: null,
-      },
-    },
-  })
-
-  response = await fetch('1')
-  expect(response.status).toEqual(200)
-  body = await response.json()
-  expect(body).toEqual({
-    data: {
-      __typename: 'Query',
-    },
-    extensions: {
-      responseCache: {
-        hit: true,
-      },
-    },
-  })
-
-  response = await fetch('2')
-
-  expect(response.status).toEqual(200)
-  body = await response.json()
-  expect(body).toEqual({
-    data: {
-      __typename: 'Query',
-    },
-    extensions: {
-      responseCache: {
-        didCache: true,
-        hit: false,
-        ttl: null,
-      },
-    },
+    expect(response.status).toEqual(200)
+    expect(await response.json()).toEqual({ data: { hi: 'Ola' } })
   })
 })


### PR DESCRIPTION
I think the response-cache should be bound to the used schema. However, right now the response cache is shared between all possible schemas.