### PR TITLE
feat: useJWT() caches JWKS

### DIFF
--- a/packages/plugins/jwt/src/index.ts
+++ b/packages/plugins/jwt/src/index.ts
@@ -156,7 +156,7 @@ function verify(
       { ...options, algorithms: options?.algorithms ?? ['RS256'] },
       (err, result) => {
         if (err) {
-          reject(unauthorizedError('Unauthenticated'));
+          reject(unauthorizedError('Failed to decode authentication token. Verification failed.'));
         } else {
           resolve(result as JwtPayload);
         }

--- a/packages/plugins/jwt/src/index.ts
+++ b/packages/plugins/jwt/src/index.ts
@@ -95,6 +95,11 @@ export function useJWT(options: JwtPluginOptions): Plugin {
 
           payloadByRequest.set(request, verified);
         } catch (error) {
+          // If error is thrown and signing key was supplied, do not attempt cache refresh
+          if (options.signingKey) {
+            throw unauthorizedError(`Unauthenticated`);
+          }
+
           // If initial verification fails, attempt to refresh the key and retry verification
           const signingKey = await fetchKey({ jwksClient, jwksCache, token, shouldRefreshCache: true });
           const verified = await verify(token, signingKey, options);

--- a/packages/plugins/jwt/src/index.ts
+++ b/packages/plugins/jwt/src/index.ts
@@ -180,7 +180,7 @@ async function fetchKey({
 }: FetchKeyOptions): Promise<string> {
   const decodedToken = decode(token, { complete: true });
   if (decodedToken?.header?.kid == null) {
-    throw unauthorizedError(`Unauthenticated`);
+    throw unauthorizedError(`Failed to decode authentication token. Missing key id.`);
   }
 
   if (shouldRefreshCache) {

--- a/packages/plugins/jwt/src/index.ts
+++ b/packages/plugins/jwt/src/index.ts
@@ -97,7 +97,7 @@ export function useJWT(options: JwtPluginOptions): Plugin {
   return {
     async onRequestParse({ request, serverContext, url }) {
       const token = await getToken({ request, serverContext, url });
-      if (token) {
+      if (token != null) {
         const signingKey = options.signingKey ?? await getSigningKeyFromJWKS(token, jwksClient, jwksCache);
 
         const verified = await verify(token, signingKey, options);

--- a/packages/plugins/jwt/src/index.ts
+++ b/packages/plugins/jwt/src/index.ts
@@ -86,8 +86,8 @@ export function useJWT(options: JwtPluginOptions): Plugin {
       const token = await getToken({ request, serverContext, url });
       if (token != null) {
         try {
-          let signingKey = options.signingKey ?? (await fetchKey({ jwksClient, jwksCache, token }));
-          let verified = await verify(token, signingKey, options);
+          const signingKey = options.signingKey ?? (await fetchKey({ jwksClient, jwksCache, token }));
+          const verified = await verify(token, signingKey, options);
 
           if (!verified) {
             throw new Error("Initial verification failed.");

--- a/packages/plugins/jwt/src/index.ts
+++ b/packages/plugins/jwt/src/index.ts
@@ -85,7 +85,7 @@ export function useJWT(options: JwtPluginOptions): Plugin {
     async onRequestParse({ request, serverContext, url }) {
       const token = await getToken({ request, serverContext, url });
       if (token != null) {
-        const signingKey = options.signingKey ?? await fetchKey(token, jwksClient, jwksCache);
+        const signingKey = options.signingKey ?? (await fetchKey(token, jwksClient, jwksCache));
 
         const verified = await verify(token, signingKey, options);
 

--- a/packages/plugins/jwt/src/index.ts
+++ b/packages/plugins/jwt/src/index.ts
@@ -146,7 +146,7 @@ function verify(
 
 async function fetchKey(token: string, jwksClient: JwksClient | undefined, jwksCache: Map<string, string>): Promise<string> {
   const decodedToken = decode(token, { complete: true });
-  if (!decodedToken?.header?.kid) {
+  if (decodedToken?.header?.kid == null) {
     throw unauthorizedError(`Failed to decode authentication token. Missing key id.`);
   }
 

--- a/packages/plugins/jwt/src/index.ts
+++ b/packages/plugins/jwt/src/index.ts
@@ -90,13 +90,10 @@ export function useJWT(options: JwtPluginOptions): Plugin {
           throw unauthorizedError(`Failed to decode authentication token. Missing key id.`);
         }
 
-        let signingKey: string;
-        if (jwksCache.has(decodedToken.header.kid)) {
-          signingKey = jwksCache.get(decodedToken.header.kid)!;
-        } else {
-          signingKey = await fetchKey(jwksClient, decodedToken.header.kid);
-          jwksCache.set(decodedToken.header.kid, signingKey);
+        if (!jwksCache.has(decodedToken.header.kid)) {
+          jwksCache.set(decodedToken.header.kid, await fetchKey(jwksClient, decodedToken.header.kid));
         }
+        const signingKey = jwksCache.get(decodedToken.header.kid)!;
 
         const verified = await verify(token, signingKey, options);
 

--- a/packages/plugins/jwt/src/index.ts
+++ b/packages/plugins/jwt/src/index.ts
@@ -144,14 +144,14 @@ function verify(
   });
 }
 
-async function fetchKey(token: string, jwksClient: JwksClient | undefined, jwksCache: Map<string, string>): Promise<string> {
+async function fetchKey(token: string, jwksClient: JwksClient, jwksCache: Map<string, string>): Promise<string> {
   const decodedToken = decode(token, { complete: true });
   if (decodedToken?.header?.kid == null) {
     throw unauthorizedError(`Failed to decode authentication token. Missing key id.`);
   }
 
   if (!jwksCache.has(decodedToken.header.kid)) {
-    const secret = await jwksClient?.getSigningKey(decodedToken.header.kid);
+    const secret = await jwksClient.getSigningKey(decodedToken.header.kid);
     const signingKey = secret?.getPublicKey();
     if (!signingKey) {
       throw unauthorizedError(`Failed to decode authentication token. Unknown key id.`);

--- a/packages/plugins/jwt/src/index.ts
+++ b/packages/plugins/jwt/src/index.ts
@@ -85,7 +85,7 @@ export function useJWT(options: JwtPluginOptions): Plugin {
     async onRequestParse({ request, serverContext, url }) {
       const token = await getToken({ request, serverContext, url });
       if (token != null) {
-        const signingKey = options.signingKey ?? (await fetchKey(token, jwksClient, jwksCache));
+        const signingKey = options.signingKey ?? (await fetchKey(jwksClient, jwksCache, token));
 
         const verified = await verify(token, signingKey, options);
 
@@ -144,7 +144,7 @@ function verify(
   });
 }
 
-async function fetchKey(token: string, jwksClient: JwksClient, jwksCache: Map<string, string>): Promise<string> {
+async function fetchKey(jwksClient: JwksClient, jwksCache: Map<string, string>, token: string): Promise<string> {
   const decodedToken = decode(token, { complete: true });
   if (decodedToken?.header?.kid == null) {
     throw unauthorizedError(`Failed to decode authentication token. Missing key id.`);


### PR DESCRIPTION
This should help us avoid running into the rate limit error, as there's no reason to spam the JWKS endpoint if we already have it available:

```sh
ERR JwksRateLimitError: Too many requests to the JWKS endpoint
    at /usr/src/app/node_modules/jwks-rsa/src/wrappers/rateLimit.js:21:16
    at processTicksAndRejections (node:internal/process/task_queues:77:11)
```

We should check the cache first, and in lieu of a valid cached value, then check the endpoint. This should probably also increase performance a good bit...

@EmrysMyrddin you've helped me out with the `useJWT()` plugin before, maybe you'd have time to take a look at this at some point? :)