### PR TITLE
Introducing GraphQL Yoga Guru on Gurubase.io

### DIFF
--- a/packages/graphql-yoga/README.md
+++ b/packages/graphql-yoga/README.md
@@ -15,6 +15,7 @@
 ![bundlephobia minified+zipped size](https://badgen.net/bundlephobia/minzip/graphql-yoga)
 ![bundlephobia treeshaking](https://badgen.net/bundlephobia/tree-shaking/graphql-yoga)
 ![license](https://badgen.net/github/license/dotansimha/graphql-yoga)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20GraphQL%20Yoga%20Guru-006BFF)](https://gurubase.io/g/graphql-yoga)
 
 </div>
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [GraphQL Yoga Guru](https://gurubase.io/g/graphql-yoga) to Gurubase. GraphQL Yoga Guru uses the data from this repo and data from the [docs](https://the-guild.dev/graphql/yoga-server) to answer questions by leveraging the LLM.

In this PR, I showcased the "GraphQL Yoga Guru", which highlights that GraphQL Yoga now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable GraphQL Yoga Guru in Gurubase, just let me know that's totally fine.
