### PR TITLE
fix: handle originally unexpected errors correctly

### DIFF
--- a/.changeset/deep-doodles-hang.md
+++ b/.changeset/deep-doodles-hang.md
@@ -1,0 +1,8 @@
+---
+'graphql-yoga': patch
+---
+
+Handle unexpected errors correctly
+
+- If `extensions.unexpected` is set, consider it as an unexpected error
+- If it has a non GraphQL Error in `originalError`, consider it as an unexpected error

--- a/.changeset/deep-doodles-hang.md
+++ b/.changeset/deep-doodles-hang.md
@@ -2,7 +2,6 @@
 'graphql-yoga': patch
 ---
 
-Handle unexpected errors correctly
+Handle unexpected errors correctly.
 
-- If `extensions.unexpected` is set, consider it as an unexpected error
-- If it has a non GraphQL Error in `originalError`, consider it as an unexpected error
+Yoga checks originalError to see if it is a wrapped error of an unexpected error, because execution engine can wrap it multiple times.

--- a/packages/graphql-yoga/__tests__/error-masking.spec.ts
+++ b/packages/graphql-yoga/__tests__/error-masking.spec.ts
@@ -760,7 +760,16 @@ describe('error masking', () => {
     ]);
   });
 
-  it('respects `unexpected` extension flag', async () => {
+  // Execution engine wraps errors recursively so the only way to make sure it is an unexpected error is to check originalError recursively
+  it('respects wrapped original errors', async () => {
+    const error = new Error('I like turtles');
+    const wrappedError = createGraphQLError('I like tortoises', {
+      originalError: error,
+    });
+    const wrappedOverWrappedError = createGraphQLError('I like animals', {
+      originalError: wrappedError,
+    });
+
     const yoga = createYoga({
       schema: createSchema({
         typeDefs: /* GraphQL */ `
@@ -770,12 +779,7 @@ describe('error masking', () => {
         `,
         resolvers: {
           Query: {
-            a: () =>
-              createGraphQLError('I like turtles', {
-                extensions: {
-                  unexpected: true,
-                },
-              }),
+            a: () => wrappedOverWrappedError,
           },
         },
       }),

--- a/packages/graphql-yoga/src/utils/mask-error.ts
+++ b/packages/graphql-yoga/src/utils/mask-error.ts
@@ -21,7 +21,7 @@ export const maskError: MaskError = (
   message: string,
   isDev = globalThis.process?.env?.['NODE_ENV'] === 'development',
 ) => {
-  if (isOriginalGraphQLError(error) && !error.extensions?.['unexpected']) {
+  if (isOriginalGraphQLError(error)) {
     return error;
   }
   const errorExtensions: Record<string, unknown> = {

--- a/packages/graphql-yoga/src/utils/mask-error.ts
+++ b/packages/graphql-yoga/src/utils/mask-error.ts
@@ -1,4 +1,3 @@
-import { GraphQLErrorOptions } from 'graphql';
 import { createGraphQLError } from '@graphql-tools/utils';
 import { isGraphQLError, isOriginalGraphQLError } from '../error.js';
 import { MaskError } from '../types.js';
@@ -22,14 +21,14 @@ export const maskError: MaskError = (
   message: string,
   isDev = globalThis.process?.env?.['NODE_ENV'] === 'development',
 ) => {
-  if (isOriginalGraphQLError(error) && !error.extensions?.unexpected) {
+  if (isOriginalGraphQLError(error) && !error.extensions?.['unexpected']) {
     return error;
   }
   const errorExtensions: Record<string, unknown> = {
     code: 'INTERNAL_SERVER_ERROR',
     unexpected: true,
   };
-  const errorOptions: GraphQLErrorOptions = {
+  const errorOptions: Parameters<typeof createGraphQLError>[1] = {
     extensions: errorExtensions,
   };
   if (isGraphQLError(error)) {

--- a/packages/graphql-yoga/src/utils/mask-error.ts
+++ b/packages/graphql-yoga/src/utils/mask-error.ts
@@ -39,8 +39,8 @@ export const maskError: MaskError = (
     if (isDev && error.originalError) {
       errorExtensions['originalError'] = serializeError(error.originalError);
     }
-    if (error.extensions?.http) {
-      errorOptions.extensions.http = error.extensions.http;
+    if (error.extensions?.['http']) {
+      errorExtensions['http'] = error.extensions['http'];
     }
   } else if (isDev) {
     errorExtensions['originalError'] = serializeError(error);

--- a/packages/graphql-yoga/src/utils/mask-error.ts
+++ b/packages/graphql-yoga/src/utils/mask-error.ts
@@ -39,6 +39,9 @@ export const maskError: MaskError = (
     if (isDev && error.originalError) {
       errorExtensions['originalError'] = serializeError(error.originalError);
     }
+    if (error.extensions?.http) {
+      errorOptions.extensions.http = error.extensions.http;
+    }
   } else if (isDev) {
     errorExtensions['originalError'] = serializeError(error);
   }

--- a/packages/graphql-yoga/src/utils/mask-error.ts
+++ b/packages/graphql-yoga/src/utils/mask-error.ts
@@ -1,52 +1,48 @@
+import { GraphQLErrorOptions } from 'graphql';
 import { createGraphQLError } from '@graphql-tools/utils';
-import { isGraphQLError } from '../error.js';
+import { isGraphQLError, isOriginalGraphQLError } from '../error.js';
 import { MaskError } from '../types.js';
+
+function serializeError(error: unknown) {
+  if (isGraphQLError(error)) {
+    return error.toJSON();
+  }
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      stack: error.stack,
+      cause: error.cause,
+    };
+  }
+  return error;
+}
 
 export const maskError: MaskError = (
   error: unknown,
   message: string,
   isDev = globalThis.process?.env?.['NODE_ENV'] === 'development',
 ) => {
-  if (isGraphQLError(error)) {
-    if (error.originalError) {
-      if (error.originalError.name === 'GraphQLError') {
-        return error;
-      }
-      return createGraphQLError(message, {
-        nodes: error.nodes,
-        source: error.source,
-        positions: error.positions,
-        path: error.path,
-        extensions: {
-          code: 'INTERNAL_SERVER_ERROR',
-          ...error.extensions,
-          unexpected: true,
-          ...(isDev
-            ? {
-                originalError: {
-                  message: error.originalError.message,
-                  stack: error.originalError.stack,
-                },
-              }
-            : {}),
-        },
-      });
-    }
+  if (isOriginalGraphQLError(error) && !error.extensions?.unexpected) {
     return error;
   }
+  const errorExtensions: Record<string, unknown> = {
+    code: 'INTERNAL_SERVER_ERROR',
+    unexpected: true,
+  };
+  const errorOptions: GraphQLErrorOptions = {
+    extensions: errorExtensions,
+  };
+  if (isGraphQLError(error)) {
+    errorOptions.nodes = error.nodes;
+    errorOptions.source = error.source;
+    errorOptions.positions = error.positions;
+    errorOptions.path = error.path;
+    if (isDev && error.originalError) {
+      errorExtensions['originalError'] = serializeError(error.originalError);
+    }
+  } else if (isDev) {
+    errorExtensions['originalError'] = serializeError(error);
+  }
 
-  return createGraphQLError(message, {
-    extensions: {
-      code: 'INTERNAL_SERVER_ERROR',
-      unexpected: true,
-      originalError: isDev
-        ? error instanceof Error
-          ? {
-              message: error.message,
-              stack: error.stack,
-            }
-          : error
-        : undefined,
-    },
-  });
+  return createGraphQLError(message, errorOptions);
 };


### PR DESCRIPTION
Related GW-297
Handle unexpected errors correctly
If it has a non GraphQL Error in `originalError`, consider it as an unexpected error (This was the same with the previous behavior but checking the original error logic wasn't working properly)