### PR TITLE
Tweak to getting started

### DIFF
--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -177,10 +177,10 @@ export const schema = new GraphQLSchema({
 
 After you have created a GraphQL schema, simply pass it in to Yoga and liftoff! 🚀
 
-```js
+```js filename="server.js"
 import { createServer } from 'node:http'
 import { createYoga } from 'graphql-yoga'
-import { schema } from './schema'
+import { schema } from './schema.js'
 
 // Create a Yoga instance with a GraphQL schema.
 const yoga = createYoga({ schema })


### PR DESCRIPTION
I was following the getting started verbatim, and made `schema.js` with the changes proposed.

I had to add `type: "module"` to my package.json (**this step is undocumented**).

I then wrote the server file to `server.js`.

When I ran it with `node server.js` I got the error:

```
$ node server.js 
node:internal/modules/run_main:128
    triggerUncaughtException(
    ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/home/benjie/Dev/DELETEME/schema-yoga/schema' imported from /home/benjie/Dev/DELETEME/schema-yoga/server.js
Did you mean to import "./schema.js"?
    at finalizeResolution (node:internal/modules/esm/resolve:265:11)
    at moduleResolve (node:internal/modules/esm/resolve:933:10)
    at defaultResolve (node:internal/modules/esm/resolve:1169:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:542:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:510:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:239:38)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:96:40)
    at link (node:internal/modules/esm/module_job:95:36) {
  code: 'ERR_MODULE_NOT_FOUND',
  url: 'file:///home/benjie/Dev/DELETEME/schema-yoga/schema'
}

Node.js v20.18.1
```

(`DELETEME` is my scratchpad folder :wink:)

The issue is that ESM in Node.js requires you to reference the file extension. So I've added the `.js`.

I recommend that you also consider adding a note to the page instructing the user to add `type: "module"` to their package.json.