### PR TITLE
chore: Update outdated links

### DIFF
--- a/examples/nextjs-auth/pages/index.tsx
+++ b/examples/nextjs-auth/pages/index.tsx
@@ -48,7 +48,7 @@ export default function Home() {
             <h2>Learn &rarr;</h2>
             <p>Learn about Next.js</p>
           </a>
-          <a href="https://graphql-yoga.vercel.app" className={styles.card}>
+          <a href="https://the-guild.dev/graphql/yoga-server" className={styles.card}>
             <h2>Learn &rarr;</h2>
             <p>Learn about GraphQL Yoga</p>
           </a>

--- a/examples/nextjs-legacy-pages/pages/index.tsx
+++ b/examples/nextjs-legacy-pages/pages/index.tsx
@@ -27,7 +27,7 @@ export default function Home() {
             <h2>Learn &rarr;</h2>
             <p>Learn about Next.js</p>
           </a>
-          <a href="https://graphql-yoga.vercel.app" className={styles.card}>
+          <a href="https://the-guild.dev/graphql/yoga-server" className={styles.card}>
             <h2>Learn &rarr;</h2>
             <p>Learn about GraphQL Yoga</p>
           </a>

--- a/examples/nextjs-ws/pages/index.tsx
+++ b/examples/nextjs-ws/pages/index.tsx
@@ -27,7 +27,7 @@ export default function Home() {
             <h2>Learn &rarr;</h2>
             <p>Learn about Next.js</p>
           </a>
-          <a href="https://graphql-yoga.vercel.app" className={styles.card}>
+          <a href="https://the-guild.dev/graphql/yoga-server" className={styles.card}>
             <h2>Learn &rarr;</h2>
             <p>Learn about GraphQL Yoga</p>
           </a>

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -100,7 +100,7 @@ export type YogaServerOptions<TServerContext, TUserContext> = Omit<
    * If you throw `EnvelopError`/`GraphQLError` within your GraphQL resolvers then that error will be sent back to the client.
    *
    * You can lean more about this here:
-   * @see https://graphql-yoga.vercel.app/docs/features/error-masking
+   * @see https://the-guild.dev/graphql/yoga-server/docs/features/error-masking
    *
    * @default true
    */


### PR DESCRIPTION
This PR updates all references to the seemingly outdated https://graphql-yoga.vercel.app website with https://the-guild.dev/graphql/yoga-server