### PR TITLE
fix(nestjs-types): Remove unused graphqlEndpoint driver option

### DIFF
--- a/packages/nestjs/src/index.ts
+++ b/packages/nestjs/src/index.ts
@@ -34,7 +34,7 @@ export type YogaDriverServerContext<Platform extends YogaDriverPlatform> =
 
 export type YogaDriverServerOptions<Platform extends YogaDriverPlatform> = Omit<
   YogaServerOptions<YogaDriverServerContext<Platform>, never>,
-  'context' | 'schema'
+  'context' | 'schema' | 'graphqlEndpoint'
 > & {
   conditionalSchema?: YogaSchemaDefinition<YogaDriverServerContext<Platform>, never> | undefined;
 };


### PR DESCRIPTION
This PR removes the unused `graphqlEndpoint` driver option type definition which is always set to Nest's `path` option inside the driver.