### PR TITLE
fix(response-cache): fix `cache` option type, fixing redis and cf-kv usage

### DIFF
--- a/.changeset/rotten-chicken-camp.md
+++ b/.changeset/rotten-chicken-camp.md
@@ -1,0 +1,6 @@
+---
+'@graphql-yoga/plugin-response-cache': patch
+---
+
+Fix types for the `cache` option. Envelop cache implementations (redis and CloudFlare KV) are now
+usable without TS errors.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "license": "MIT",
   "private": true,
-  "packageManager": "pnpm@10.16.1",
+  "packageManager": "pnpm@10.15.1",
   "engines": {
     "node": ">=18.0.0",
     "pnpm": ">=9.1.3"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "build": "pnpm --filter=@graphql-yoga/graphiql run build && pnpm --filter=@graphql-yoga/render-graphiql run build && pnpm --filter=graphql-yoga run generate-graphiql-html && bob build && pnpm --filter=graphql-yoga run inject-version",
     "build-website": "pnpm build && cd website && pnpm build",
     "changeset": "changeset",
-    "check": "pnpm --parallel -r run check",
+    "check": "pnpm -r run check",
     "check:types": "tsc --pretty --noEmit",
     "lint": "cross-env \"ESLINT_USE_FLAT_CONFIG=false\" eslint --ext ts,js,tsx,jsx .",
     "postchangeset": "pnpm install --no-frozen-lockfile",

--- a/packages/plugins/response-cache/__tests__/response-cache.spec.ts
+++ b/packages/plugins/response-cache/__tests__/response-cache.spec.ts
@@ -4,6 +4,8 @@ import {
   defaultBuildResponseCacheKey,
   ShouldCacheResultFunction,
 } from '@envelop/response-cache';
+import { createKvCache } from '@envelop/response-cache-cloudflare-kv';
+import { createRedisCache } from '@envelop/response-cache-redis';
 import { useDeferStream } from '@graphql-yoga/plugin-defer-stream';
 import { createInMemoryCache, useResponseCache } from '@graphql-yoga/plugin-response-cache';
 
@@ -1468,3 +1470,8 @@ it('should work correctly with batching and async race conditions', async () => 
 ]
 `);
 });
+
+// Cache types compatibility tests
+useResponseCache({ cache: createInMemoryCache(), session: () => null });
+useResponseCache({ cache: createRedisCache({} as any), session: () => null });
+useResponseCache({ cache: createKvCache({} as any)({} as any), session: () => null });

--- a/packages/plugins/response-cache/__tests__/response-cache.spec.ts
+++ b/packages/plugins/response-cache/__tests__/response-cache.spec.ts
@@ -1472,6 +1472,7 @@ it('should work correctly with batching and async race conditions', async () => 
 });
 
 // Cache types compatibility tests
+/* eslint-disable @typescript-eslint/no-explicit-any */
 useResponseCache({ cache: createInMemoryCache(), session: () => null });
 useResponseCache({ cache: createRedisCache({} as any), session: () => null });
 useResponseCache({ cache: createKvCache({} as any)({} as any), session: () => null });

--- a/packages/plugins/response-cache/package.json
+++ b/packages/plugins/response-cache/package.json
@@ -52,6 +52,8 @@
     "@whatwg-node/promise-helpers": "^1.2.4"
   },
   "devDependencies": {
+    "@envelop/response-cache-cloudflare-kv": "^4.0.0",
+    "@envelop/response-cache-redis": "^4.2.4",
     "graphql": "16.11.0",
     "graphql-yoga": "workspace:*",
     "tslib": "^2.6.2"

--- a/packages/plugins/response-cache/src/index.ts
+++ b/packages/plugins/response-cache/src/index.ts
@@ -60,16 +60,14 @@ export interface ResponseCachePluginExtensions {
   http?: {
     headers?: Record<string, string>;
   };
-  responseCache: EnvelopResponseCacheExtensions;
+  responseCache?: EnvelopResponseCacheExtensions;
   [key: string]: unknown;
 }
 
 export interface Cache extends EnvelopCache {
   get(
     key: string,
-  ): PromiseOrValue<
-    ExecutionResult<Record<string, unknown>, ResponseCachePluginExtensions> | undefined
-  >;
+  ): PromiseOrValue<Maybe<ExecutionResult<Record<string, unknown>, ResponseCachePluginExtensions>>>;
 }
 
 export function useResponseCache<TContext = YogaInitialContext>(

--- a/packages/plugins/sofa/src/__tests__/sofa.spec.ts
+++ b/packages/plugins/sofa/src/__tests__/sofa.spec.ts
@@ -19,9 +19,9 @@ it('should be able to invoke graphql query w/ plugin active', async () => {
     schema,
     plugins: [
       useSofa({
-        basePath: "/rest",
+        basePath: '/rest',
         swaggerUI: {
-            endpoint: "/swagger",
+          endpoint: '/swagger',
         },
       }),
     ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2158,6 +2158,12 @@ importers:
         specifier: ^1.2.4
         version: 1.3.2
     devDependencies:
+      '@envelop/response-cache-cloudflare-kv':
+        specifier: ^4.0.0
+        version: 4.0.0(@cloudflare/workers-types@4.20250913.0)(@envelop/response-cache@8.0.0(@envelop/core@5.3.0)(graphql@16.11.0))(graphql@16.11.0)
+      '@envelop/response-cache-redis':
+        specifier: ^4.2.4
+        version: 4.2.4(@envelop/core@5.3.0)(graphql@16.11.0)
       graphql:
         specifier: 16.11.0
         version: 16.11.0
@@ -2552,7 +2558,6 @@ packages:
     deprecated: |-
       AWS CDK v1 has reached End-of-Support on 2023-06-01.
       This package is no longer being updated, and users should migrate to AWS CDK v2.
-
       For more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html
     peerDependencies:
       '@aws-cdk/aws-certificatemanager': 1.204.0
@@ -2829,7 +2834,6 @@ packages:
     deprecated: |-
       AWS CDK v1 has reached End-of-Support on 2023-06-01.
       This package is no longer being updated, and users should migrate to AWS CDK v2.
-
       For more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html
     peerDependencies:
       '@aws-cdk/aws-applicationautoscaling': 1.204.0
@@ -3017,7 +3021,6 @@ packages:
     deprecated: |-
       AWS CDK v1 has reached End-of-Support on 2023-06-01.
       This package is no longer being updated, and users should migrate to AWS CDK v2.
-
       For more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html
     peerDependencies:
       '@aws-cdk/cloud-assembly-schema': 1.204.0
@@ -3992,6 +3995,21 @@ packages:
       '@envelop/core': ^5.3.0
       graphql: 16.11.0
       prom-client: ^15.0.0
+
+  '@envelop/response-cache-cloudflare-kv@4.0.0':
+    resolution: {integrity: sha512-w9V52eIxMDcw4BnsW4bkcBqBvDjViNAslehQvQaysF47lIxrZFrw781K0hsg/b4ViQUMgd4269JmpEy/4F8OiQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20231121.0
+      '@envelop/response-cache': ^8.0.0
+      graphql: 16.11.0
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
+  '@envelop/response-cache-redis@4.2.4':
+    resolution: {integrity: sha512-9RG15sio0fX4ZoHEoQYgbm6BCc2rXzdNkPQ7Q+jLKWyi7sBY0w+ocYJhOttN6vh3nNa1kNN9wrJup732V2/4eA==}
+    engines: {node: '>=18.0.0'}
 
   '@envelop/response-cache@8.0.0':
     resolution: {integrity: sha512-ClCeq6ALZsKUjKn4ueTAntHWPshKctCbRH3oeSZrFZWDpfK2DVqPntnKLg1PHduFPlZJhdo+c8KfyL4ZfB0MNQ==}
@@ -19073,6 +19091,25 @@ snapshots:
       prom-client: 15.1.3
       tslib: 2.8.1
 
+  '@envelop/response-cache-cloudflare-kv@4.0.0(@cloudflare/workers-types@4.20250913.0)(@envelop/response-cache@8.0.0(@envelop/core@5.3.0)(graphql@16.11.0))(graphql@16.11.0)':
+    dependencies:
+      '@envelop/response-cache': 8.0.0(@envelop/core@5.3.0)(graphql@16.11.0)
+      graphql: 16.11.0
+      tslib: 2.8.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20250913.0
+
+  '@envelop/response-cache-redis@4.2.4(@envelop/core@5.3.0)(graphql@16.11.0)':
+    dependencies:
+      '@envelop/response-cache': 8.0.0(@envelop/core@5.3.0)(graphql@16.11.0)
+      '@whatwg-node/promise-helpers': 1.3.2
+      ioredis: 5.7.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@envelop/core'
+      - graphql
+      - supports-color
+
   '@envelop/response-cache@8.0.0(@envelop/core@5.3.0)(graphql@16.11.0)':
     dependencies:
       '@envelop/core': 5.3.0
@@ -26837,7 +26874,7 @@ snapshots:
       eslint: 9.35.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-react: 7.37.5(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.35.0(jiti@2.5.1))
@@ -26875,7 +26912,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -26966,7 +27003,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
This PR fixes the type incompatibility between `Cache` type from Envelop and `Cache` type from Yoga.

There was 2 things that was wrong:
 - The GraphQL response extension `responseCache` was marked as required, which is false (you can disable response cache metadata with `includeExtensionMetadata` option.
 - The return type of `Cache.get` in Yoga disallows `null` values, while Envelop allows it. Based on code, Envelop is the correct one, as `null` and `undefined` are handled the same way.

I have marked this change as a patch since the types were actually wrong, but this can of course trigger errors in existing setup (since I'm making `responseCache` extension nullable). Should we mark it as a major because of this?

Related to #3048
Related to YOGA-78