### PR TITLE
chore: update Deno examples and references

### DIFF
--- a/examples/deno/index.ts
+++ b/examples/deno/index.ts
@@ -1,7 +1,6 @@
-import { serve } from 'https://deno.land/std@0.157.0/http/server.ts';
 import { yoga } from './yoga.ts';
 
-serve(yoga, {
+Deno.serve(yoga, {
   onListen({ hostname, port }) {
     console.log(`Listening on http://${hostname}:${port}${yoga.graphqlEndpoint}`);
   },

--- a/examples/deno/index.ts
+++ b/examples/deno/index.ts
@@ -1,7 +1,10 @@
 import { yoga } from './yoga.ts';
 
-Deno.serve(yoga, {
-  onListen({ hostname, port }) {
-    console.log(`Listening on http://${hostname}:${port}${yoga.graphqlEndpoint}`);
+Deno.serve(
+  {
+    onListen({ hostname, port }) {
+      console.log(`Listening on http://${hostname}:${port}${yoga.graphqlEndpoint}`);
+    },
   },
-});
+  yoga,
+);

--- a/examples/deno/package.json
+++ b/examples/deno/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "check": "deno test --import-map ../../import-map.json --unstable --allow-env --allow-net --no-check ./test.ts",
-    "start": "deno run --import-map ../../import-map.json --unstable --allow-env --allow-net index.ts"
+    "check": "deno test --import-map ../../import-map.json --allow-env --allow-net --no-check ./test.ts",
+    "start": "deno run --import-map ../../import-map.json --allow-env --allow-net index.ts"
   }
 }

--- a/examples/deno/test.ts
+++ b/examples/deno/test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from 'https://deno.land/std@0.158.0/testing/asserts.ts';
+import { assertEquals } from 'jsr:@std/assert';
 import { yoga } from './yoga.ts';
 
 Deno.test('Deno example test', async () => {

--- a/import-map.json
+++ b/import-map.json
@@ -10,9 +10,11 @@
     "graphql": "npm:graphql",
     "dset": "npm:dset",
     "@envelop/core": "npm:@envelop/core@5",
+    "@envelop/instrumentation": "npm:@envelop/instrumentation",
     "@envelop/parser-cache": "npm:@envelop/parser-cache",
     "@whatwg-node/fetch": "npm:@whatwg-node/fetch",
     "@whatwg-node/events": "npm:@whatwg-node/events@0.0.3",
+    "@whatwg-node/promise-helpers": "npm:@whatwg-node/promise-helpers",
     "@whatwg-node/server": "npm:@whatwg-node/server",
     "@repeaterjs/repeater": "npm:@repeaterjs/repeater",
     "lru-cache": "npm:lru-cache@^9.0.0"

--- a/website/src/content/docs/integrations/integration-with-deno.mdx
+++ b/website/src/content/docs/integrations/integration-with-deno.mdx
@@ -8,7 +8,7 @@ description:
 
 GraphQL Yoga provides you a cross-platform GraphQL Server. So you can easily integrate it into any
 platform besides Node.js.
-[Deno is a simple, modern and secure runtime for JavaScript and TypeScript that uses V8 and is built in Rust](https://deno.land/).
+[Deno is a simple, modern and secure runtime for JavaScript and TypeScript that uses V8 and is built in Rust](https://deno.com/).
 We will use `graphql-yoga` which has an agnostic HTTP handler using
 [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch)'s
 [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) and
@@ -17,7 +17,7 @@ We will use `graphql-yoga` which has an agnostic HTTP handler using
 ## Example
 
 Create a `deno.json` file.
-[Learn more about import maps](https://deno.land/manual/basics/import_maps)
+[Learn more about import maps](https://docs.deno.com/runtime/fundamentals/modules/#managing-third-party-modules-and-libraries)
 
 Create a `deno-yoga.ts` file:
 
@@ -31,7 +31,6 @@ Create a `deno-yoga.ts` file:
 
 ```ts filename="deno-yoga.ts"
 import { createSchema, createYoga } from 'graphql-yoga'
-import { serve } from 'https://deno.land/std@0.157.0/http/server.ts'
 
 const yoga = createYoga({
   schema: createSchema({
@@ -48,7 +47,7 @@ const yoga = createYoga({
   })
 })
 
-serve(yoga, {
+Deno.serve(yoga, {
   onListen({ hostname, port }) {
     console.log(`Listening on http://${hostname}:${port}/${yoga.graphqlEndpoint}`)
   }


### PR DESCRIPTION
- docs are hosted under .com
- Deno.serve stabilised a while back
- add imports w/o which example scripts wouldn't run
- stop using `--unstable` as it's been removed in v2 and isn't serving any significant purpose in examples