### PR TITLE
fix documents: use seconds instead of milliseconds in Using Schema directive section

### DIFF
--- a/website/src/content/docs/features/response-caching.mdx
+++ b/website/src/content/docs/features/response-caching.mdx
@@ -190,11 +190,11 @@ const typeDefs = /* GraphQL */ `
 
   type Query {
     # cache operations selecting Query.lazy for 10 seconds
-    lazy: Something @cacheControl(maxAge: 10000)
+    lazy: Something @cacheControl(maxAge: 10)
   }
 
-  # only cache query operations containing User for 500ms
-  type User @cacheControl(maxAge: 500) {
+  # only cache query operations containing User for 1 second
+  type User @cacheControl(maxAge: 1) {
     #...
   }
 `


### PR DESCRIPTION
The document is wrong.

`maxAge` must be in seconds, not in milliseconds.

https://github.com/graphql-hive/envelop/blob/b6c44632877192481bec9e25a0e45b86bb4ab82e/packages/plugins/response-cache/src/plugin.ts#L377