### PR TITLE
feat(subscription): add configurable repeater buffer to createPubSub

### DIFF
--- a/.changeset/configurable-repeater-buffer.md
+++ b/.changeset/configurable-repeater-buffer.md
@@ -1,0 +1,24 @@
+---
+'@graphql-yoga/subscription': minor
+---
+
+feat: add configurable repeater buffer to createPubSub
+
+This allows users to configure how values are buffered when pushed faster than consumed,
+preventing RepeaterOverflowError when more than 1024 pending pushes accumulate.
+
+Available buffers from @repeaterjs/repeater:
+- `FixedBuffer(capacity)` - allows N values to be pushed without waiting, throws when full
+- `SlidingBuffer(capacity)` - discards oldest values when capacity is exceeded
+- `DroppingBuffer(capacity)` - discards newest values when capacity is exceeded
+
+Example:
+```ts
+import { createPubSub, SlidingBuffer } from '@graphql-yoga/subscription';
+
+const pubSub = createPubSub({
+  repeaterBuffer: new SlidingBuffer(256)
+});
+```
+
+Closes #3692

--- a/packages/subscription/src/create-pub-sub.ts
+++ b/packages/subscription/src/create-pub-sub.ts
@@ -1,5 +1,5 @@
 import type { TypedEventTarget } from '@graphql-yoga/typed-event-target';
-import { Repeater } from '@repeaterjs/repeater';
+import { Repeater, type RepeaterBuffer } from '@repeaterjs/repeater';
 import { CustomEvent } from '@whatwg-node/events';
 
 type PubSubPublishArgsByKey = {
@@ -31,6 +31,27 @@ export type ChannelPubSubConfig<TPubSubPublishArgsByKey extends PubSubPublishArg
    * An event dispatched on the event target MUST have a `data` property.
    */
   eventTarget?: PubSubEventTarget<TPubSubPublishArgsByKey>;
+  /**
+   * A buffer for the repeater that controls how values are buffered when pushed faster than consumed.
+   * By default, no buffer is used and a RepeaterOverflowError is thrown when more than 1024
+   * pending pushes accumulate.
+   *
+   * Available buffers from @repeaterjs/repeater:
+   * - FixedBuffer(capacity) - allows N values to be pushed without waiting, throws when full
+   * - SlidingBuffer(capacity) - discards oldest values when capacity is exceeded
+   * - DroppingBuffer(capacity) - discards newest values when capacity is exceeded
+   *
+   * @example
+   * ```ts
+   * import { createPubSub } from '@graphql-yoga/subscription';
+   * import { SlidingBuffer } from '@repeaterjs/repeater';
+   *
+   * const pubSub = createPubSub({
+   *   repeaterBuffer: new SlidingBuffer(256)
+   * });
+   * ```
+   */
+  repeaterBuffer?: RepeaterBuffer;
 };
 
 export type PubSub<TPubSubPublishArgsByKey extends PubSubPublishArgsByKey> = {
@@ -63,6 +84,7 @@ export const createPubSub = <TPubSubPublishArgsByKey extends PubSubPublishArgsBy
 ): PubSub<TPubSubPublishArgsByKey> => {
   const target =
     config?.eventTarget ?? (new EventTarget() as PubSubEventTarget<TPubSubPublishArgsByKey>);
+  const repeaterBuffer = config?.repeaterBuffer;
 
   return {
     publish<TKey extends Extract<keyof TPubSubPublishArgsByKey, string>>(
@@ -98,7 +120,7 @@ export const createPubSub = <TPubSubPublishArgsByKey extends PubSubPublishArgsBy
         function pubsubEventListener(event: PubSubEvent<TPubSubPublishArgsByKey, TKey>) {
           next(event.detail);
         }
-      });
+      }, repeaterBuffer);
     },
   };
 };

--- a/packages/subscription/src/createPubSub.spec.ts
+++ b/packages/subscription/src/createPubSub.spec.ts
@@ -1,5 +1,6 @@
 import Redis from 'ioredis-mock';
 import { createRedisEventTarget } from '@graphql-yoga/redis-event-target';
+import { DroppingBuffer, FixedBuffer, SlidingBuffer } from '@repeaterjs/repeater';
 import { createPubSub } from './create-pub-sub.js';
 
 async function collectAsyncIterableValues<TType>(
@@ -148,6 +149,91 @@ describe('createPubSub', () => {
 
       const result = await allValues;
       expect(result).toEqual([null, null, null]);
+    });
+  });
+
+  describe('repeaterBuffer', () => {
+    it('uses SlidingBuffer to handle overflow', async () => {
+      const pubSub = createPubSub<{
+        a: [number];
+      }>({
+        repeaterBuffer: new SlidingBuffer(3),
+      });
+
+      const sub = pubSub.subscribe('a');
+      const allValues = collectAsyncIterableValues(sub);
+
+      // Push more values than buffer capacity
+      // First value (1) goes directly to the waiting consumer
+      // Remaining values go to buffer: 2,3,4,5
+      // SlidingBuffer(3) keeps last 3, so 2 slides out → buffer has [3,4,5]
+      pubSub.publish('a', 1);
+      pubSub.publish('a', 2);
+      pubSub.publish('a', 3);
+      pubSub.publish('a', 4);
+      pubSub.publish('a', 5);
+
+      setImmediate(() => {
+        sub.return();
+      });
+
+      const result = await allValues;
+      // First value (1) bypasses buffer, then buffer drains [3,4,5]
+      expect(result).toEqual([1, 3, 4, 5]);
+    });
+
+    it('uses DroppingBuffer to handle overflow', async () => {
+      const pubSub = createPubSub<{
+        a: [number];
+      }>({
+        repeaterBuffer: new DroppingBuffer(3),
+      });
+
+      const sub = pubSub.subscribe('a');
+      const allValues = collectAsyncIterableValues(sub);
+
+      // Push more values than buffer capacity
+      // First value (1) goes directly to the waiting consumer
+      // Remaining values go to buffer: 2,3,4,5
+      // DroppingBuffer(3) keeps first 3, so 5 is dropped → buffer has [2,3,4]
+      pubSub.publish('a', 1);
+      pubSub.publish('a', 2);
+      pubSub.publish('a', 3);
+      pubSub.publish('a', 4);
+      pubSub.publish('a', 5);
+
+      setImmediate(() => {
+        sub.return();
+      });
+
+      const result = await allValues;
+      // First value (1) bypasses buffer, then buffer drains [2,3,4]
+      expect(result).toEqual([1, 2, 3, 4]);
+    });
+
+    it('uses FixedBuffer with higher capacity', async () => {
+      const pubSub = createPubSub<{
+        a: [number];
+      }>({
+        repeaterBuffer: new FixedBuffer(5),
+      });
+
+      const sub = pubSub.subscribe('a');
+      const allValues = collectAsyncIterableValues(sub);
+
+      pubSub.publish('a', 1);
+      pubSub.publish('a', 2);
+      pubSub.publish('a', 3);
+      pubSub.publish('a', 4);
+      pubSub.publish('a', 5);
+
+      setImmediate(() => {
+        sub.return();
+      });
+
+      const result = await allValues;
+      // FixedBuffer with capacity 5 keeps all 5 values
+      expect(result).toEqual([1, 2, 3, 4, 5]);
     });
   });
 });

--- a/packages/subscription/src/index.ts
+++ b/packages/subscription/src/index.ts
@@ -3,4 +3,10 @@ export { createPubSub } from './create-pub-sub.js';
 export { filter } from './operator/filter.js';
 export { map } from './operator/map.js';
 export { pipe } from './utils/pipe.js';
-export { Repeater } from '@repeaterjs/repeater';
+export {
+  Repeater,
+  FixedBuffer,
+  SlidingBuffer,
+  DroppingBuffer,
+  type RepeaterBuffer,
+} from '@repeaterjs/repeater';


### PR DESCRIPTION
Add 'repeaterBuffer' option to ChannelPubSubConfig that allows users to configure how values are buffered when pushed faster than consumed. This prevents RepeaterOverflowError when more than 1024 pending pushes accumulate.

- Add repeaterBuffer option to createPubSub config
- Export FixedBuffer, SlidingBuffer, DroppingBuffer, RepeaterBuffer from @graphql-yoga/subscription
- Add comprehensive tests for buffer behavior
- Add changeset

Closes #3692