### PR TITLE
Bump whatwg node server

### DIFF
--- a/.changeset/graphql-yoga-4513-dependencies.md
+++ b/.changeset/graphql-yoga-4513-dependencies.md
@@ -1,0 +1,5 @@
+---
+"graphql-yoga": patch
+---
+dependencies updates:
+  - Updated dependency [`@whatwg-node/server@^0.11.0` ↗︎](https://www.npmjs.com/package/@whatwg-node/server/v/0.11.0) (from `^0.10.14`, in `dependencies`)

--- a/packages/graphql-yoga/package.json
+++ b/packages/graphql-yoga/package.json
@@ -58,7 +58,7 @@
     "@graphql-yoga/subscription": "workspace:^",
     "@whatwg-node/fetch": "^0.10.6",
     "@whatwg-node/promise-helpers": "^1.3.2",
-    "@whatwg-node/server": "^0.10.14",
+    "@whatwg-node/server": "^0.11.0",
     "lru-cache": "^10.0.0",
     "tslib": "^2.8.1"
   },

--- a/packages/plugins/apollo-inline-trace/package.json
+++ b/packages/plugins/apollo-inline-trace/package.json
@@ -52,7 +52,7 @@
     "@graphql-tools/delegate": "^11.0.0",
     "@graphql-tools/federation": "^4.0.0",
     "@whatwg-node/fetch": "^0.10.6",
-    "@whatwg-node/server": "^0.10.14",
+    "@whatwg-node/server": "^0.11.0",
     "graphql": "16.12.0",
     "graphql-yoga": "workspace:*"
   },

--- a/packages/plugins/apollo-managed-federation/package.json
+++ b/packages/plugins/apollo-managed-federation/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@whatwg-node/fetch": "^0.10.6",
-    "@whatwg-node/server": "^0.10.14",
+    "@whatwg-node/server": "^0.11.0",
     "graphql": "16.12.0",
     "graphql-yoga": "workspace:^",
     "typescript": "6.0.2"

--- a/packages/plugins/defer-stream/package.json
+++ b/packages/plugins/defer-stream/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@graphql-tools/executor-http": "^3.0.0",
     "@whatwg-node/fetch": "^0.10.6",
-    "@whatwg-node/server": "^0.10.14",
+    "@whatwg-node/server": "^0.11.0",
     "fetch-multipart-graphql": "3.2.2",
     "graphql": "16.12.0",
     "graphql-yoga": "workspace:*",

--- a/packages/subscription/package.json
+++ b/packages/subscription/package.json
@@ -65,7 +65,7 @@
   "devDependencies": {
     "@graphql-yoga/redis-event-target": "workspace:*",
     "@types/ioredis-mock": "8.2.6",
-    "@whatwg-node/server": "^0.10.14",
+    "@whatwg-node/server": "^0.11.0",
     "ioredis-mock": "8.13.1"
   },
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3307,8 +3307,8 @@ importers:
         specifier: ^1.3.2
         version: 1.3.2
       '@whatwg-node/server':
-        specifier: ^0.10.14
-        version: 0.10.18
+        specifier: ^0.11.0
+        version: 0.11.0
       lru-cache:
         specifier: ^10.0.0
         version: 10.4.3
@@ -3519,8 +3519,8 @@ importers:
         specifier: ^0.10.6
         version: 0.10.13
       '@whatwg-node/server':
-        specifier: ^0.10.14
-        version: 0.10.18
+        specifier: ^0.11.0
+        version: 0.11.0
       graphql:
         specifier: 16.13.2
         version: 16.13.2
@@ -3542,8 +3542,8 @@ importers:
         specifier: ^0.10.6
         version: 0.10.13
       '@whatwg-node/server':
-        specifier: ^0.10.14
-        version: 0.10.18
+        specifier: ^0.11.0
+        version: 0.11.0
       graphql:
         specifier: 16.13.2
         version: 16.13.2
@@ -3633,8 +3633,8 @@ importers:
         specifier: ^0.10.6
         version: 0.10.13
       '@whatwg-node/server':
-        specifier: ^0.10.14
-        version: 0.10.18
+        specifier: ^0.11.0
+        version: 0.11.0
       fetch-multipart-graphql:
         specifier: 3.2.2
         version: 3.2.2
@@ -3856,8 +3856,8 @@ importers:
         specifier: 8.2.6
         version: 8.2.6(ioredis@5.8.2)
       '@whatwg-node/server':
-        specifier: ^0.10.14
-        version: 0.10.18
+        specifier: ^0.11.0
+        version: 0.11.0
       ioredis-mock:
         specifier: 8.13.1
         version: 8.13.1(@types/ioredis-mock@8.2.6(ioredis@5.8.2))(ioredis@5.8.2)
@@ -10849,6 +10849,10 @@ packages:
 
   '@whatwg-node/server@0.10.18':
     resolution: {integrity: sha512-kMwLlxUbduttIgaPdSkmEarFpP+mSY8FEm+QWMBRJwxOHWkri+cxd8KZHO9EMrB9vgUuz+5WEaCawaL5wGVoXg==}
+    engines: {node: '>=18.0.0'}
+
+  '@whatwg-node/server@0.11.0':
+    resolution: {integrity: sha512-VSdkwnJRr8Yv9UgB2aXB3VUPWwd6Oqnn0hycFwhg9pZgWxJXb7JmhsiXe9tmpMwjHFxli12PGcz9aI63YYloGQ==}
     engines: {node: '>=18.0.0'}
 
   '@wry/caches@1.0.1':
@@ -29355,6 +29359,14 @@ snapshots:
       tslib: 2.8.1
 
   '@whatwg-node/server@0.10.18':
+    dependencies:
+      '@envelop/instrumentation': 1.0.0
+      '@whatwg-node/disposablestack': 0.0.6
+      '@whatwg-node/fetch': 0.10.13
+      '@whatwg-node/promise-helpers': 1.3.2
+      tslib: 2.8.1
+
+  '@whatwg-node/server@0.11.0':
     dependencies:
       '@envelop/instrumentation': 1.0.0
       '@whatwg-node/disposablestack': 0.0.6


### PR DESCRIPTION
I bumped a minor with https://github.com/ardatan/whatwg-node/pull/3399, but whatwg node server uses zero-based versioning making this a breaking change - even though it's not.