### PR TITLE
chore(deps-peer): bump newrelic peer dep in @envelop/newrelic

### DIFF
--- a/.changeset/shiny-lands-judge.md
+++ b/.changeset/shiny-lands-judge.md
@@ -1,0 +1,5 @@
+---
+'@envelop/newrelic': patch
+---
+
+Bump newrelic latest peer dependency from 11 to 14

--- a/packages/envelop/plugins/newrelic/package.json
+++ b/packages/envelop/plugins/newrelic/package.json
@@ -49,7 +49,7 @@
   "peerDependencies": {
     "@envelop/core": "workspace:^",
     "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0",
-    "newrelic": ">=7 <12"
+    "newrelic": ">=7 <15"
   },
   "dependencies": {
     "@envelop/on-resolve": "workspace:^",


### PR DESCRIPTION
The current `newrelic` range is `>= 7 < 12` when version `14.1.0` is the latest.

Almost all breaking changes are around dropping / updating support for instrumentation of specific packages. No breaking changes seem to affect this plugin.

We have been using this plugin with version 13 for several months with no issue, except pnpm warnings.

### Summary of changes:

- `newrelic` 12 [changelog](https://github.com/newrelic/node-newrelic/blob/main/NEWS.md#v1200-2024-07-31)
  - drops node 16 node support
  - removed a legacy api that `@envelop/newrelic` doesn't use
  - updates min supported version of packages for instrumentation, doesn't affect this package
- `newrelic` 13 [changelog](https://github.com/newrelic/node-newrelic/blob/main/NEWS.md#v1300-2025-07-23)
  - drops node 18 support
  - updates min supported version of packages for instrumentation
- `newrelic` 14 [changelog](https://github.com/newrelic/node-newrelic/blob/main/NEWS.md#v1400-2026-05-18)
  - drops node 20 support
  - removed instrumentation support for various packages
  - updated min supported version of packages for instrumentation
  - removed "Cross Application Tracing(CAT)" functionality (deprecation announced in v8, 2021 [source](https://github.com/newrelic/node-newrelic/issues/3415))
  - removed support for License, Application, and Security Policies ("No known Node customers are using this feature" [source](https://github.com/newrelic/node-newrelic/issues/3538))