### PR TITLE
Add graphql-yoga npm homepage and bugs metadata

### DIFF
--- a/packages/graphql-yoga/package.json
+++ b/packages/graphql-yoga/package.json
@@ -89,5 +89,9 @@
   "sideEffects": false,
   "typescript": {
     "definition": "dist/typings/index.d.ts"
+  },
+  "homepage": "https://github.com/graphql-hive/graphql-yoga/tree/main/packages/graphql-yoga",
+  "bugs": {
+    "url": "https://github.com/graphql-hive/graphql-yoga/issues"
   }
 }


### PR DESCRIPTION
## Summary

Add missing npm metadata for the published `graphql-yoga` package:

- `homepage` points to the package directory in this repository
- `bugs.url` points to the repository issue tracker

The package already had `repository` metadata with the package directory, so this completes the standard npm source/issues metadata surface without runtime changes.

## Verification

```sh
npm view graphql-yoga name version homepage repository bugs --json
node -e "const pkg=require('./packages/graphql-yoga/package.json'); for (const k of ['homepage','repository','bugs']) { if (!pkg[k]) throw new Error(k+' missing'); } if (!String(pkg.homepage).includes('github.com/graphql-hive/graphql-yoga/tree/main/packages/graphql-yoga')) throw new Error('homepage mismatch'); if (!String(pkg.repository.url).includes('github.com/graphql-hive/graphql-yoga.git')) throw new Error('repository mismatch'); if (!String(pkg.bugs.url).endsWith('/issues')) throw new Error('bugs mismatch'); console.log('metadata smoke ok');"
npm pack --dry-run --ignore-scripts ./packages/graphql-yoga
git diff --check
```

Results:

- Published `graphql-yoga@5.21.2` currently exposes `repository`, but no `homepage` or `bugs` metadata.
- Metadata smoke printed `metadata smoke ok`.
- `npm pack --dry-run --ignore-scripts ./packages/graphql-yoga` completed successfully.
- `git diff --check` passed.
