### PR TITLE
chore: add response cache package metadata

### DIFF
--- a/.changeset/quiet-caches-report.md
+++ b/.changeset/quiet-caches-report.md
@@ -1,0 +1,5 @@
+---
+"@graphql-yoga/plugin-response-cache": patch
+---
+
+Add npm homepage and bugs metadata for the package.

--- a/packages/plugins/response-cache/package.json
+++ b/packages/plugins/response-cache/package.json
@@ -8,6 +8,10 @@
     "url": "https://github.com/graphql-hive/graphql-yoga.git",
     "directory": "packages/plugins/response-cache"
   },
+  "homepage": "https://the-guild.dev/graphql/yoga-server/docs/features/response-caching",
+  "bugs": {
+    "url": "https://github.com/graphql-hive/graphql-yoga/issues"
+  },
   "author": "Arda TANRIKULU <ardatanrikulu@gmail.com>",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
## Summary
- add npm `homepage` metadata for `@graphql-yoga/plugin-response-cache`
- add npm `bugs.url` metadata pointing to the GitHub issue tracker
- add a patch changeset for the metadata update

## Verification
- `node -e "JSON.parse(require('fs').readFileSync('packages/plugins/response-cache/package.json','utf8')); console.log('package.json OK')"`
- `git diff --check`
