### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/plugins/response-cache/package.json
+++ b/packages/plugins/response-cache/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@graphql-yoga/plugin-response-cache",
   "version": "3.23.2",
+  "bugs": {
+    "url": "https://github.com/graphql-hive/graphql-yoga/issues"
+  },
   "type": "module",
   "description": "",
   "repository": {


### PR DESCRIPTION
Adds missing `bugs` metadata to `packages/plugins/response-cache/package.json`.

Fixes npm tooling unable to resolve package metadata.