### PR TITLE
Rate limiter field config `identifier` template string option and `identityFn` with args

### DIFF
--- a/.changeset/fancy-pillows-say.md
+++ b/.changeset/fancy-pillows-say.md
@@ -1,0 +1,30 @@
+---
+'@envelop/rate-limiter': minor
+---
+
+Field config now accepts an `identifier` template string as a lightweight alternative to `identifyFn`
+
+Supports `{args.argName}` and `{context.propName}` dot-path interpolation, equivalent to using
+`@rateLimit(identityArgs: [...])` via the directive but available in programmatic config.
+
+```ts
+useRateLimiter({
+  identifyFn: ctx => ctx.ip,
+  configByField: [
+    {
+      type: 'Query',
+      field: 'getProduct',
+      window: '1m',
+      max: 10,
+      identifier: '{args.id}',
+    },
+    {
+      type: 'Query',
+      field: 'search',
+      window: '1m',
+      max: 30,
+      identifier: '{context.ip}',
+    },
+  ],
+})
+```

--- a/.changeset/sixty-seven-good.md
+++ b/.changeset/sixty-seven-good.md
@@ -1,0 +1,27 @@
+---
+'@envelop/rate-limiter': minor
+---
+
+`identifyFn` now receives field argument values as a second parameter when used via `configByField`
+
+The per-field `identifyFn` on `ConfigByField` receives the resolved argument values, making it
+straightforward to rate limit unauthenticated requests by argument value without a directive.
+
+```ts
+useRateLimiter({
+  identifyFn: ctx => ctx.ip,
+  configByField: [
+    {
+      type: 'Query',
+      field: 'getProduct', // getProduct(id: ID!): Product!
+      window: '1m',
+      max: 10,
+      identifyFn: (ctx, args) => String(args.id),
+    },
+  ],
+})
+```
+
+Note: the root `identifyFn` also receives args as a second parameter when it acts as the fallback
+for a `configByField` entry, but args will be empty when it is invoked for directive-based rate
+limiting.

--- a/packages/envelop/plugins/rate-limiter/src/index.ts
+++ b/packages/envelop/plugins/rate-limiter/src/index.ts
@@ -87,6 +87,13 @@ export type RateLimitDirectiveArgs = {
   max?: number;
   window?: string;
   message?: string;
+  /**
+   * Field argument names whose values are included in the rate limit key, creating a separate
+   * bucket per unique combination of values. Equivalent to `@rateLimit(identityArgs: [...])`.
+   *
+   * @example
+   * identityArgs: ['id']  // one bucket per unique id argument value
+   */
   identityArgs?: string[];
   arrayLengthField?: string;
   readOnly?: boolean;

--- a/packages/envelop/plugins/rate-limiter/src/index.ts
+++ b/packages/envelop/plugins/rate-limiter/src/index.ts
@@ -1,4 +1,3 @@
-import get from 'lodash.get';
 import { isPromise } from 'node:util/types';
 import type {
   GraphQLError,
@@ -16,6 +15,7 @@ import {
   visit,
   visitWithTypeInfo,
 } from 'graphql';
+import get from 'lodash.get';
 import picomatch from 'picomatch';
 import type { Plugin } from '@envelop/core';
 import {
@@ -220,9 +220,6 @@ export const useRateLimiter = (options: RateLimiterPluginOptions): Plugin<RateLi
               }
 
               const resolverRateLimitConfig = { ...rateLimitConfig };
-              const identifier = rateLimitConfig?.identifier
-                ? resolveIdentifierTemplate(rateLimitConfig.identifier, getArgValues, context)
-                : (rateLimitConfig?.identifyFn ?? options.identifyFn)(context);
 
               let args: Record<string, any> | null = null;
               function getArgValues(): Record<string, any> {
@@ -231,6 +228,10 @@ export const useRateLimiter = (options: RateLimiterPluginOptions): Plugin<RateLi
                 }
                 return args ?? {};
               }
+
+              const identifier = rateLimitConfig?.identifier
+                ? resolveIdentifierTemplate(rateLimitConfig.identifier, getArgValues, context)
+                : (rateLimitConfig?.identifyFn ?? options.identifyFn)(context);
 
               const executionArgs = {
                 identifier,

--- a/packages/envelop/plugins/rate-limiter/src/index.ts
+++ b/packages/envelop/plugins/rate-limiter/src/index.ts
@@ -45,7 +45,10 @@ export {
   type Options,
 };
 
-export type IdentifyFn<ContextType = unknown> = (context: ContextType) => string;
+export type IdentifyFn<ContextType = unknown> = (
+  context: ContextType,
+  args: Record<string, unknown>,
+) => string;
 
 interface RateLimitExecutionParams<ContextType = unknown> {
   root: unknown;
@@ -97,14 +100,30 @@ export type RateLimiterPluginOptions = {
 export interface ConfigByField extends RateLimitDirectiveArgs {
   type: string;
   field: string;
+  /**
+   * Override the identity function for this specific field. Receives the context and the
+   * resolved field argument values, and must return a string that uniquely identifies the
+   * caller. Takes precedence over the plugin-level `identifyFn`.
+   *
+   * Use this when the identity for a field comes from a combination of context and arguments,
+   * for example to rate limit unauthenticated requests per argument value.
+   *
+   * @example
+   * // rate limit per product id for unauthenticated requests for `getProduct(id: ID!)` field
+   * identifyFn: (ctx, args) => String(args.id)
+   */
   identifyFn?: IdentifyFn;
   /**
-   * A template string to build the rate limit identity key from the execution context.
-   * Supports `{args.argName}` and `{context.propName}` interpolation.
+   * A template string that builds the rate limit identity key from the execution context.
+   * Supports `{args.argName}` and `{context.propName}` dot-path interpolation via lodash.get.
+   * Takes precedence over `identifyFn` when set.
    *
-   * Example: `"{args.productId}"` or `"{context.ip}"`
+   * Use this as a lightweight alternative to `identifyFn` when the identity can be expressed
+   * as a single field path rather than a function.
    *
-   * When set, takes precedence over `identifyFn` for this field.
+   * @example
+   * identifier: "{args.id}"       // per-argument bucket
+   * identifier: "{context.ip}"    // per-ip bucket, no auth needed
    */
   identifier?: string;
 }
@@ -123,7 +142,7 @@ const getTypeInfo = memoize1(function getTypeInfo(schema: GraphQLSchema) {
 export const useRateLimiter = (options: RateLimiterPluginOptions): Plugin<RateLimiterContext> => {
   const rateLimiterFn = getGraphQLRateLimiter({
     ...options,
-    identifyContext: options.identifyFn,
+    identifyContext: context => options.identifyFn(context, {}),
   });
 
   const interpolateMessage = options.interpolateMessage || defaultInterpolateMessageFn;
@@ -231,7 +250,7 @@ export const useRateLimiter = (options: RateLimiterPluginOptions): Plugin<RateLi
 
               const identifier = rateLimitConfig?.identifier
                 ? resolveIdentifierTemplate(rateLimitConfig.identifier, getArgValues, context)
-                : (rateLimitConfig?.identifyFn ?? options.identifyFn)(context);
+                : (rateLimitConfig?.identifyFn ?? options.identifyFn)(context, getArgValues());
 
               const executionArgs = {
                 identifier,

--- a/packages/envelop/plugins/rate-limiter/src/index.ts
+++ b/packages/envelop/plugins/rate-limiter/src/index.ts
@@ -45,6 +45,13 @@ export {
   type Options,
 };
 
+/**
+ * Returns a string that uniquely identifies the caller for rate limiting.
+ *
+ * Receives the execution context and the resolved field argument values. Note that `args` is
+ * only populated when the function is invoked via `configByField`. When used as the plugin-level
+ * `identifyFn` for directive-based rate limiting, `args` will be an empty object.
+ */
 export type IdentifyFn<ContextType = unknown> = (
   context: ContextType,
   args: Record<string, unknown>,
@@ -101,29 +108,25 @@ export interface ConfigByField extends RateLimitDirectiveArgs {
   type: string;
   field: string;
   /**
-   * Override the identity function for this specific field. Receives the context and the
-   * resolved field argument values, and must return a string that uniquely identifies the
-   * caller. Takes precedence over the plugin-level `identifyFn`.
+   * Override the identity function for this specific field. Takes precedence over the
+   * plugin-level `identifyFn`.
    *
-   * Use this when the identity for a field comes from a combination of context and arguments,
-   * for example to rate limit unauthenticated requests per argument value.
+   * Unlike the plugin-level `identifyFn`, this is always called with the resolved field
+   * argument values, making it suitable for unauthenticated rate limiting keyed on an argument.
    *
    * @example
-   * // rate limit per product id for unauthenticated requests for `getProduct(id: ID!)` field
    * identifyFn: (ctx, args) => String(args.id)
    */
   identifyFn?: IdentifyFn;
   /**
-   * A template string that builds the rate limit identity key from the execution context.
-   * Supports `{args.argName}` and `{context.propName}` dot-path interpolation via lodash.get.
-   * Takes precedence over `identifyFn` when set.
+   * A template string that builds the rate limit identity key using `{args.argName}` or
+   * `{context.propName}` dot-path interpolation. Takes precedence over `identifyFn` when set.
    *
-   * Use this as a lightweight alternative to `identifyFn` when the identity can be expressed
-   * as a single field path rather than a function.
+   * Use this as a concise alternative to `identifyFn` when the identity is a single path.
    *
    * @example
-   * identifier: "{args.id}"       // per-argument bucket
-   * identifier: "{context.ip}"    // per-ip bucket, no auth needed
+   * identifier: "{args.id}"      // one bucket per argument value
+   * identifier: "{context.ip}"   // one bucket per ip, no auth required
    */
   identifier?: string;
 }

--- a/packages/envelop/plugins/rate-limiter/src/index.ts
+++ b/packages/envelop/plugins/rate-limiter/src/index.ts
@@ -1,3 +1,4 @@
+import get from 'lodash.get';
 import { isPromise } from 'node:util/types';
 import type {
   GraphQLError,
@@ -97,6 +98,15 @@ export interface ConfigByField extends RateLimitDirectiveArgs {
   type: string;
   field: string;
   identifyFn?: IdentifyFn;
+  /**
+   * A template string to build the rate limit identity key from the execution context.
+   * Supports `{args.argName}` and `{context.propName}` interpolation.
+   *
+   * Example: `"{args.productId}"` or `"{context.ip}"`
+   *
+   * When set, takes precedence over `identifyFn` for this field.
+   */
+  identifier?: string;
 }
 
 export const defaultInterpolateMessageFn: MessageInterpolator = (message, identifier) =>
@@ -137,6 +147,7 @@ export const useRateLimiter = (options: RateLimiterPluginOptions): Plugin<RateLi
     type?: string;
     field?: string;
     identifyFn?: IdentifyFn;
+    identifier?: string;
     max?: number;
     window?: string;
     message?: string;
@@ -184,7 +195,7 @@ export const useRateLimiter = (options: RateLimiterPluginOptions): Plugin<RateLi
 
     rateLimitConfig.max = Number(rateLimitConfig.max);
 
-    if (rateLimitConfig?.identifyFn) {
+    if (rateLimitConfig?.identifyFn || rateLimitConfig?.identifier) {
       rateLimitConfig.identityArgs = ['identifier', ...(rateLimitConfig.identityArgs ?? [])];
     }
 
@@ -209,14 +220,16 @@ export const useRateLimiter = (options: RateLimiterPluginOptions): Plugin<RateLi
               }
 
               const resolverRateLimitConfig = { ...rateLimitConfig };
-              const identifier = (rateLimitConfig?.identifyFn ?? options.identifyFn)(context);
+              const identifier = rateLimitConfig?.identifier
+                ? resolveIdentifierTemplate(rateLimitConfig.identifier, getArgValues, context)
+                : (rateLimitConfig?.identifyFn ?? options.identifyFn)(context);
 
               let args: Record<string, any> | null = null;
-              function getArgValues() {
+              function getArgValues(): Record<string, any> {
                 if (!args && field) {
                   args = getArgumentValues(field, node, variableValues);
                 }
-                return args;
+                return args ?? {};
               }
 
               const executionArgs = {
@@ -342,6 +355,16 @@ export const useRateLimiter = (options: RateLimiterPluginOptions): Plugin<RateLi
 
 function interpolateByArgs(message: string, args: { [key: string]: string }) {
   return message.replace(/\{{([^)]*)\}}/g, (_, key) => args[key.trim()] as string);
+}
+
+function resolveIdentifierTemplate(
+  template: string,
+  getArgValues: () => Record<string, any>,
+  context: any,
+): string {
+  return template.replace(/\{([^}]+)\}/g, (_, path: string) =>
+    String(get({ args: getArgValues(), context }, path.trim()) ?? ''),
+  );
 }
 
 export { InMemoryStore } from './in-memory-store.js';

--- a/packages/envelop/plugins/rate-limiter/tests/use-rate-limiter.spec.ts
+++ b/packages/envelop/plugins/rate-limiter/tests/use-rate-limiter.spec.ts
@@ -13,7 +13,7 @@ describe('Rate-Limiter', () => {
     const schemaWithDirective = makeExecutableSchema({
       typeDefs: `
     ${DIRECTIVE_SDL}
-    
+
     type Query {
       limited: String @rateLimit(
         max: 1,
@@ -49,7 +49,7 @@ describe('Rate-Limiter', () => {
               readOnly: Boolean
               uncountRejected: Boolean
             ) on FIELD_DEFINITION
-    
+
             type Query {
               limited: String @customDirective(
                 max: 1,
@@ -131,7 +131,7 @@ describe('Rate-Limiter', () => {
       const schema = makeExecutableSchema({
         typeDefs: `
       ${DIRECTIVE_SDL}
-      
+
       type Query {
         limited: String @rateLimit(
           max: 1,
@@ -511,5 +511,81 @@ describe('Rate-Limiter', () => {
       expect(result).toEqual({ data: { unlimitedField: 'unlimited' } });
       expect(result.errors).toBeUndefined();
     }
+  });
+  it('should rate limit per-arg when identifier template uses {args.*}', async () => {
+    const schema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          getProduct(id: ID!): String
+        }
+      `,
+      resolvers: {
+        Query: {
+          getProduct: (_root, args) => args['id'] as string,
+        },
+      },
+    });
+    const testkit = createTestkit(
+      [
+        useRateLimiter({
+          identifyFn: () => 'anonymous',
+          configByField: [
+            {
+              type: 'Query',
+              field: 'getProduct',
+              max: 1,
+              window: '60s',
+              identifier: '{args.id}',
+            },
+          ],
+        }),
+      ],
+      schema,
+    );
+    // first call for product A should succeed
+    const r1 = await testkit.execute(`{ getProduct(id: "A") }`);
+    expect(r1).toEqual({ data: { getProduct: 'A' } });
+    // second call for product A should be rate limited
+    const r2 = await testkit.execute(`{ getProduct(id: "A") }`);
+    assertSingleExecutionValue(r2);
+    expect(r2.errors?.[0]?.message).toBe("You are trying to access 'getProduct' too often");
+    // call for product B should succeed because it has its own bucket
+    const r3 = await testkit.execute(`{ getProduct(id: "B") }`);
+    expect(r3).toEqual({ data: { getProduct: 'B' } });
+  });
+  it('should rate limit per-context-value when identifier template uses {context.*}', async () => {
+    const schema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          ping: String
+        }
+      `,
+      resolvers: { Query: { ping: () => 'pong' } },
+    });
+    const testkit = createTestkit(
+      [
+        useRateLimiter({
+          identifyFn: () => 'fallback',
+          configByField: [
+            {
+              type: 'Query',
+              field: 'ping',
+              max: 1,
+              window: '60s',
+              identifier: '{context.ip}',
+            },
+          ],
+        }),
+      ],
+      schema,
+    );
+    const r1 = await testkit.execute(`{ ping }`, {}, { ip: '1.2.3.4' });
+    expect(r1).toEqual({ data: { ping: 'pong' } });
+    const r2 = await testkit.execute(`{ ping }`, {}, { ip: '1.2.3.4' });
+    assertSingleExecutionValue(r2);
+    expect(r2.errors?.[0]?.message).toBe("You are trying to access 'ping' too often");
+    // different ip gets its own bucket
+    const r3 = await testkit.execute(`{ ping }`, {}, { ip: '9.9.9.9' });
+    expect(r3).toEqual({ data: { ping: 'pong' } });
   });
 });

--- a/packages/envelop/plugins/rate-limiter/tests/use-rate-limiter.spec.ts
+++ b/packages/envelop/plugins/rate-limiter/tests/use-rate-limiter.spec.ts
@@ -512,6 +512,46 @@ describe('Rate-Limiter', () => {
       expect(result.errors).toBeUndefined();
     }
   });
+  it('should rate limit per-arg using identityArgs in configByField', async () => {
+    const schema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          getProduct(id: ID!): String
+        }
+      `,
+      resolvers: {
+        Query: {
+          getProduct: (_root, args) => args['id'] as string,
+        },
+      },
+    });
+    const testkit = createTestkit(
+      [
+        useRateLimiter({
+          identifyFn: () => 'anonymous',
+          configByField: [
+            {
+              type: 'Query',
+              field: 'getProduct',
+              max: 1,
+              window: '60s',
+              identityArgs: ['id'],
+            },
+          ],
+        }),
+      ],
+      schema,
+    );
+    const r1 = await testkit.execute(`{ getProduct(id: "A") }`);
+    expect(r1).toEqual({ data: { getProduct: 'A' } });
+    // second call for the same id is rate limited
+    const r2 = await testkit.execute(`{ getProduct(id: "A") }`);
+    assertSingleExecutionValue(r2);
+    expect(r2.errors?.[0]?.message).toBe("You are trying to access 'getProduct' too often");
+    // different id gets its own bucket
+    const r3 = await testkit.execute(`{ getProduct(id: "B") }`);
+    expect(r3).toEqual({ data: { getProduct: 'B' } });
+  });
   it('should rate limit per-arg when identifier template uses {args.*}', async () => {
     const schema = makeExecutableSchema({
       typeDefs: /* GraphQL */ `

--- a/packages/envelop/plugins/rate-limiter/tests/use-rate-limiter.spec.ts
+++ b/packages/envelop/plugins/rate-limiter/tests/use-rate-limiter.spec.ts
@@ -163,7 +163,7 @@ describe('Rate-Limiter', () => {
       assertSingleExecutionValue(result);
 
       expect(result.errors!.length).toBe(1);
-      expect(result.errors![0]!.message).toBe(`too many calls for ${identifyFn({})}`);
+      expect(result.errors![0]!.message).toBe(`too many calls for ${identifyFn({}, {})}`);
       expect(result.errors![0]!.path).toEqual(['limited']);
     });
   });


### PR DESCRIPTION
- Field config now accepts an `identifier` template string as a lightweight alternative to `identifyFn`
- `identifyFn` now receives field argument values as a second parameter when used via `configByField`