### PR TITLE
fix: guard result-processor `cancel` against undefined iterator

### DIFF
--- a/packages/graphql-yoga/src/plugins/result-processor/multipart.ts
+++ b/packages/graphql-yoga/src/plugins/result-processor/multipart.ts
@@ -73,7 +73,7 @@ export function processMultipartResult(result: ResultProcessorInput, fetchAPI: F
       );
     },
     cancel(e) {
-      if (iterator.return) {
+      if (iterator && iterator.return) {
         return handleMaybePromise(
           () => iterator.return?.(e),
           () => {},

--- a/packages/graphql-yoga/src/plugins/result-processor/sse.ts
+++ b/packages/graphql-yoga/src/plugins/result-processor/sse.ts
@@ -82,7 +82,7 @@ export function getSSEProcessor(): ResultProcessor {
       },
       cancel(e) {
         clearInterval(pingInterval);
-        if (iterator.return) {
+        if (iterator && iterator.return) {
           return handleMaybePromise(
             () => iterator.return?.(e),
             () => {},


### PR DESCRIPTION
### Problem

`getSSEProcessor`'s `ReadableStream` `cancel(e)` callback references `iterator` before it is guaranteed to be defined:

```js
const readableStream = new fetchAPI.ReadableStream({
  start(controller) {
    // ...
    iterator = result[Symbol.asyncIterator]() // assigned here
  },
  cancel(e) {
    clearInterval(pingInterval)
    if (iterator.return) {   // 💥 iterator may be undefined
      return handleMaybePromise(() => iterator.return?.(e), () => {})
    }
  }
})
```

`iterator` is assigned inside `start(controller)`, but `cancel` can fire **before `start` runs** — e.g. when the underlying `ServerResponse`/stream is destroyed during teardown before initialization completes. In that case `iterator` is still `undefined`, and `iterator.return` throws:

```
TypeError: Cannot read properties of undefined (reading 'return')
    at Object.cancel (.../graphql-yoga/esm/plugins/result-processor/sse.js:71:30)
    at Readable.destroy [as _destroy] (.../@whatwg-node/node-fetch/cjs/ReadableStream.js:109:59)
    ...
    at ServerResponse.<anonymous> (.../fastify/lib/reply.js:798:17)
```

### Impact in production

This is not a rare edge case under load. With GraphQL subscriptions served over SSE, clients disconnect frequently (page refreshes, navigation, network drops, reconnects), and each teardown routes through `cancel`. Observed in a production Fastify + Yoga deployment serving live tournament subscriptions:

- The `TypeError` is emitted at **high volume** (thousands per second during peak), surfacing as `response terminated with an error with headers already sent` warnings.
- Each occurrence pays the cost of throwing an `Error` and capturing a stack trace, which adds measurable **CPU and log-I/O overhead** on the event loop — compounding the very overload that triggers the teardowns.
- The error is also noisy/ misleading in monitoring since it implies a real failure when the stream was already being torn down harmlessly.

### Fix

Guard the reference so `cancel` is a no-op when the iterator hasn't been initialized yet (mirroring the existing `?.` usage on `iterator.return`):

```diff
   cancel(e) {
     clearInterval(pingInterval);
-    if (iterator.return) {
+    if (iterator && iterator.return) {
       return handleMaybePromise(() => iterator.return?.(e), () => { });
     }
   },
```

### Verification

- Reproduced reliably under concurrent-subscription load (SSE) with frequent client disconnects; the `TypeError` flood stops entirely with the guard in place.
- `start`/`pull`/happy-path subscription behaviour is unchanged — when `iterator` is defined, `cancel` cleans up exactly as before.
- Applied (via `patch-package`) and confirmed in production: the warning volume dropped to zero with no behavioural regression.

### Notes

- I personally observed the issue and tested the fix on `getSSEProcessor`. For consistency I implemented the same fix in `processMultipartResult`
- An alternative would be to initialize `iterator` synchronously (outside `start`) so it's never `undefined`, but the guard is the minimal, lowest-risk change and keeps the lazy initialization semantics intact.