### PR TITLE
fix: keep SSE keep-alive pings during stream backpressure

### DIFF
--- a/.changeset/sse-ping-backpressure.md
+++ b/.changeset/sse-ping-backpressure.md
@@ -1,0 +1,5 @@
+---
+'graphql-yoga': patch
+---
+
+Keep SSE keep-alive pings running when the stream reports backpressure (`desiredSize === 0`) instead of treating a full queue as a closed connection.

--- a/packages/graphql-yoga/__tests__/subscriptions.spec.ts
+++ b/packages/graphql-yoga/__tests__/subscriptions.spec.ts
@@ -249,6 +249,7 @@ data:
           hi: {
             async *subscribe() {
               await d.promise;
+              yield;
             },
           },
         },

--- a/packages/graphql-yoga/__tests__/subscriptions.spec.ts
+++ b/packages/graphql-yoga/__tests__/subscriptions.spec.ts
@@ -2,7 +2,7 @@ import { setTimeout as setTimeout$ } from 'node:timers/promises';
 import { GraphQLError } from 'graphql';
 import { createDeferredPromise, fakePromise } from '@whatwg-node/server';
 import type { Plugin } from '../src/index.js';
-import { createSchema, createYoga, maskError } from '../src/index.js';
+import { createSchema, createYoga, getSSEProcessor, maskError } from '../src/index.js';
 import { eventStream } from './utilities.js';
 
 describe('Subscription', () => {
@@ -233,89 +233,70 @@ data:
   });
 
   test('should keep issuing pings after momentary stream backpressure', async () => {
-    const d = createDeferredPromise();
+    jest.useFakeTimers();
 
-    const schema = createSchema({
-      typeDefs: /* GraphQL */ `
-        type Subscription {
-          hi: String!
-        }
-        type Query {
-          hi: String!
-        }
-      `,
-      resolvers: {
-        Subscription: {
-          hi: {
-            async *subscribe() {
-              await d.promise;
-              yield;
-            },
-          },
-        },
-      },
-    });
+    let desiredSize: number | null = 1;
+    let pings = 0;
+    let cancelStream: (() => void | Promise<void>) | undefined;
+    const decoder = new TextDecoder();
 
     // Node's default fetch ponyfill stores a static `_read()` size, so it never
     // reports WHATWG backpressure (`desiredSize === 0`). Deno, Bun, Workers, and
-    // Node's global streams do.
-    const yoga = createYoga({
-      schema,
-      fetchAPI: {
-        ReadableStream: globalThis.ReadableStream,
-        Response: globalThis.Response,
-        TextEncoder: globalThis.TextEncoder,
-      },
-    });
+    // Node's global streams do. native streams also trip jest --detectLeaks, so we
+    // drive desiredSize on a fake controller instead.
+    try {
+      getSSEProcessor()(
+        { [Symbol.asyncIterator]: () => ({ next: () => new Promise(() => {}) }) },
+        {
+          TextEncoder,
+          Response: class {
+            constructor(public body: unknown) {}
+          },
+          ReadableStream: class {
+            constructor(source: {
+              start(controller: {
+                readonly desiredSize: number | null;
+                enqueue(chunk: Uint8Array): void;
+                close(): void;
+                error(err: unknown): void;
+              }): void;
+              cancel?(reason?: unknown): void | Promise<void>;
+            }) {
+              cancelStream = () => source.cancel?.();
+              source.start({
+                get desiredSize() {
+                  return desiredSize;
+                },
+                enqueue(chunk) {
+                  if (decoder.decode(chunk) === ':\n\n') {
+                    pings++;
+                  }
+                },
+                close() {},
+                error() {},
+              });
+            }
+          },
+        } as never,
+        'text/event-stream',
+      );
 
-    const response = await yoga.fetch('http://yoga/graphql', {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        accept: 'text/event-stream',
-      },
-      body: JSON.stringify({
-        query: /* GraphQL */ `
-          subscription {
-            hi
-          }
-        `,
-      }),
-    });
+      expect(pings).toBe(1);
 
-    const reader = response.body!.getReader();
-    const decoder = new TextDecoder();
+      // Default CountQueuingStrategy high-water mark is 1. The next ping fills the queue
+      // (desiredSize === 0). A second tick while unread is what a falsy desiredSize check
+      // treats as "stream dead", permanently clearing the timer.
+      desiredSize = 0;
+      await jest.advanceTimersByTimeAsync(300 * 3);
+      expect(pings).toBe(1);
 
-    const opening = await reader.read();
-    expect(decoder.decode(opening.value)).toBe(':\n\n');
-
-    // Default CountQueuingStrategy high-water mark is 1. The next ping fills the queue
-    // (desiredSize === 0). A second tick while unread is what a falsy desiredSize check
-    // treats as "stream dead", permanently clearing the timer.
-    await setTimeout$(300 * 3 + 80);
-
-    let pingCount = 0;
-    const deadline = Date.now() + 300 * 5 + 100;
-    while (pingCount < 3 && Date.now() < deadline) {
-      const remaining = deadline - Date.now();
-      const chunk = await Promise.race([
-        reader.read(),
-        setTimeout$(Math.max(remaining, 1)).then(() => null),
-      ]);
-      if (chunk == null || chunk.done || chunk.value == null) {
-        break;
-      }
-      for (const frame of decoder.decode(chunk.value).split('\n\n')) {
-        if (frame === ':') {
-          pingCount++;
-        }
-      }
+      desiredSize = 1;
+      await jest.advanceTimersByTimeAsync(300 * 3);
+      expect(pings).toBeGreaterThanOrEqual(4);
+    } finally {
+      await cancelStream?.();
+      jest.useRealTimers();
     }
-
-    d.resolve();
-    await reader.cancel();
-
-    expect(pingCount).toBeGreaterThanOrEqual(3);
   });
 
   test('erroring event stream should be handled (non GraphQL error)', async () => {

--- a/packages/graphql-yoga/__tests__/subscriptions.spec.ts
+++ b/packages/graphql-yoga/__tests__/subscriptions.spec.ts
@@ -1,4 +1,3 @@
-import { setTimeout as setTimeout$ } from 'node:timers/promises';
 import { GraphQLError } from 'graphql';
 import { createDeferredPromise, fakePromise } from '@whatwg-node/server';
 import type { Plugin } from '../src/index.js';

--- a/packages/graphql-yoga/__tests__/subscriptions.spec.ts
+++ b/packages/graphql-yoga/__tests__/subscriptions.spec.ts
@@ -1,3 +1,4 @@
+import { setTimeout as setTimeout$ } from 'node:timers/promises';
 import { GraphQLError } from 'graphql';
 import { createDeferredPromise, fakePromise } from '@whatwg-node/server';
 import type { Plugin } from '../src/index.js';
@@ -229,6 +230,91 @@ data:
       ",
       ]
     `);
+  });
+
+  test('should keep issuing pings after momentary stream backpressure', async () => {
+    const d = createDeferredPromise();
+
+    const schema = createSchema({
+      typeDefs: /* GraphQL */ `
+        type Subscription {
+          hi: String!
+        }
+        type Query {
+          hi: String!
+        }
+      `,
+      resolvers: {
+        Subscription: {
+          hi: {
+            async *subscribe() {
+              await d.promise;
+            },
+          },
+        },
+      },
+    });
+
+    // Node's default fetch ponyfill stores a static `_read()` size, so it never
+    // reports WHATWG backpressure (`desiredSize === 0`). Deno, Bun, Workers, and
+    // Node's global streams do.
+    const yoga = createYoga({
+      schema,
+      fetchAPI: {
+        ReadableStream: globalThis.ReadableStream,
+        Response: globalThis.Response,
+        TextEncoder: globalThis.TextEncoder,
+      },
+    });
+
+    const response = await yoga.fetch('http://yoga/graphql', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'text/event-stream',
+      },
+      body: JSON.stringify({
+        query: /* GraphQL */ `
+          subscription {
+            hi
+          }
+        `,
+      }),
+    });
+
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+
+    const opening = await reader.read();
+    expect(decoder.decode(opening.value)).toBe(':\n\n');
+
+    // Default CountQueuingStrategy high-water mark is 1. The next ping fills the queue
+    // (desiredSize === 0). A second tick while unread is what a falsy desiredSize check
+    // treats as "stream dead", permanently clearing the timer.
+    await setTimeout$(300 * 3 + 80);
+
+    let pingCount = 0;
+    const deadline = Date.now() + 300 * 5 + 100;
+    while (pingCount < 3 && Date.now() < deadline) {
+      const remaining = deadline - Date.now();
+      const chunk = await Promise.race([
+        reader.read(),
+        setTimeout$(Math.max(remaining, 1)).then(() => null),
+      ]);
+      if (chunk == null || chunk.done || chunk.value == null) {
+        break;
+      }
+      for (const frame of decoder.decode(chunk.value).split('\n\n')) {
+        if (frame === ':') {
+          pingCount++;
+        }
+      }
+    }
+
+    d.resolve();
+    await reader.cancel();
+
+    expect(pingCount).toBeGreaterThanOrEqual(3);
   });
 
   test('erroring event stream should be handled (non GraphQL error)', async () => {

--- a/packages/graphql-yoga/src/plugins/result-processor/sse.ts
+++ b/packages/graphql-yoga/src/plugins/result-processor/sse.ts
@@ -37,11 +37,14 @@ export function getSSEProcessor(): ResultProcessor {
 
         // ping client every 12 seconds to keep the connection alive
         pingInterval = setInterval(() => {
-          if (!controller.desiredSize) {
+          // `null` is errored. `0` is backpressure or closed; do not treat it as terminal.
+          if (controller.desiredSize === null) {
             clearInterval(pingInterval);
             return;
           }
-          controller.enqueue(textEncoder.encode(':\n\n'));
+          if (controller.desiredSize > 0) {
+            controller.enqueue(textEncoder.encode(':\n\n'));
+          }
         }, pingIntervalMs) as unknown as number;
 
         if (isAsyncIterable(result)) {


### PR DESCRIPTION
## Summary

SSE keep-alive pings (`:` every 12s, 300ms under `NODE_ENV=test`) skip a tick when `controller.desiredSize` is `0` or negative, and clear the interval only when `desiredSize === null`. `pull()` and `cancel()` already clear the interval when the stream actually ends.

The old check was `if (!controller.desiredSize)`. On a WHATWG `ReadableStreamDefaultController`, `desiredSize === 0` means the queue is at its high-water mark (backpressure) or the stream is closed. `null` is errored only. A slow consumer that filled the default HWM of 1 cleared the ping interval permanently, even after it started reading again.

Fixes #4548

## Decision

Skip enqueue under backpressure and only treat `null` as terminal. The issue's snippet enqueues whenever `desiredSize !== null` and lets the JS queue grow. `0` cannot distinguish closed from backpressure, and enqueueing into a closed controller throws. Pings stuck in a full JS queue never reach a proxy. Skipping avoids unbounded growth while keeping keep-alives able to resume. Can switch to always-enqueue.

## Test plan

- [x] New test in `packages/graphql-yoga/__tests__/subscriptions.spec.ts`: pause consumption until a second ping tick sees `desiredSize === 0`, resume, assert >= 3 further pings (fails on the old falsy check, passes after the fix). Uses `createYoga({ fetchAPI })` with Node's global streams because the default Node fetch ponyfill stores a static `_read()` size and never reports WHATWG backpressure.
- [x] Existing SSE ping tests in `subscriptions.spec.ts` and `graphql-sse.spec.ts` still pass.
- [ ] Unit job on graphql-js 15/16/17 (CI matrix).
